### PR TITLE
improve scraping by collecting links first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-house.txt
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ ARG LD_FLAGS
 WORKDIR /go/src/github.com/vladikamira/funda-exporter
 COPY . .
 
-#ENV GOOS=linux
-#ENV GOARCH=arm
-#ENV GOARM=7
 RUN go version
 RUN go mod vendor
 RUN GO111MODULE=on CGO_ENABLED=0 go build -mod vendor -ldflags "$LD_FLAGS" -o /go/bin/app .

--- a/Readme.md
+++ b/Readme.md
@@ -1,2 +1,37 @@
 # funda-exporter
 This is a scraper of Funda.nl website which presenting collected data as Prometheus series
+
+Scraping initiated on the GET request call from metrics collector (Prometheus), so keep in mind that depends on the Funda URL it can take several minutes to finish.
+So please consider to set relatively high `scrape_interval` and `scrape_timeout`.
+
+Docker images could be found here: `vladikamira/funda-exporter:TAG_NAME`
+
+example to run with docker-compose:
+```
+version: "3.8"
+services:
+  funda-exporter:
+    container_name: funda-exporter
+    restart: always
+    image: vladikamira/funda-exporter:v0.0.2
+    command:
+      - '-scrapeDelayMilliseconds=500'
+      - '-fundaSearchUrl=https://www.funda.nl/koop/amstelveen,amsterdam/300000-440000/70+woonopp/2+slaapkamers/'
+      - '-listenAddress=:2112'
+    ports:
+      - 2112:2112
+```
+
+and Prometheus scraping config could looks like that:
+```
+global:
+  scrape_interval: 1m
+
+scrape_configs:
+
+  - job_name: 'funda-exporter'
+    scrape_interval: 30m
+    scrape_timeout: 29m
+    static_configs:
+    - targets: ['funda-exporter:2112']
+```

--- a/deploy/data/vmagent/prometheus.yml
+++ b/deploy/data/vmagent/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 1m
+
+scrape_configs:
+
+  - job_name: 'funda-exporter'
+    scrape_interval: 30m
+    scrape_timeout: 29m
+    static_configs:
+    - targets: ['funda-exporter:2112']

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,52 @@
+version: "3.8"
+services:
+
+  vmagent:
+    container_name: vmagent
+    image: victoriametrics/vmagent:v1.86.1
+    depends_on:
+      - "vmsingle"
+    ports:
+      - 8429:8429
+    volumes:
+      - ./data/vmagent/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - "--promscrape.config=/etc/prometheus/prometheus.yml"
+      - "--promscrape.configCheckInterval=1m"
+      - "--remoteWrite.url=http://vmsingle:8428/api/v1/write"
+    restart: always
+
+  vmsingle:
+    container_name: vmsingle
+    image: victoriametrics/victoria-metrics:v1.86.1
+    ports:
+      - 8428:8428
+    command:
+      - "--storageDataPath=/storage"
+      - "--httpListenAddr=:8428"
+      - "--retentionPeriod=48"
+    restart: always
+
+  grafana:
+    container_name: grafana
+    image: grafana/grafana:9.3.6
+    depends_on:
+      - "vmsingle"
+    ports:
+      - 3000:3000
+    restart: always
+
+  funda-exporter:
+    container_name: funda-exporter
+    restart: always
+    image: vladikamira/funda-exporter:v0.0.2
+    command:
+      - '-scrapeDelayMilliseconds=500'
+      - '-fundaSearchUrl=https://www.funda.nl/koop/amstelveen,amsterdam/300000-440000/70+woonopp/2+slaapkamers/'
+      - '-listenAddress=:2112'
+    ports:
+      - 2112:2112
+    depends_on:
+      - "vmagent"
+    environment:
+      - GOMAXPROCS=1

--- a/main.go
+++ b/main.go
@@ -13,10 +13,9 @@ import (
 )
 
 var (
-	FakeUserAgent = flag.String("fakeUserAgent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
-		"A fake User-Agent")
-	FundaSearchUrl = flag.String("fundaSearchUrl", "https://www.funda.nl/koop/amstelveen,amsterdam/300000-440000/70+woonopp/2+slaapkamers/",
-		"Funda search page with paramethers")
+	FakeUserAgent = flag.String("fakeUserAgent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36", "A fake User-Agent")
+	FundaSearchUrl = flag.String("fundaSearchUrl", "https://www.funda.nl/koop/amstelveen,amsterdam/300000-440000/70+woonopp/2+slaapkamers/", "Funda search page with paramethers")
+//	FundaSearchUrl = flag.String("fundaSearchUrl", "https://www.funda.nl/koop/amsterdam/buitenveldert-oost,buitenveldert-west,zuidas/300000-440000/70+woonopp/2+slaapkamers/", "Funda search page with paramethers")
 	ScrapeDelayMilliseconds = flag.Int("scrapeDelayMilliseconds", 1000, "Delay between scrapes. Let's not overload Funda :)")
 	ListenAddress = flag.String("listenAddress", ":2112", "Address to listen")
 )


### PR DESCRIPTION
previously we run Search apartment and parse them, then go to the second search page with parsing.
The problem is that results cold be changed during scraping, so it's better to have all links firs and only then scrape.